### PR TITLE
Use `encodeURIComponent` in Spotify search string

### DIFF
--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -283,7 +283,7 @@ async function setActivity(rpc: Client) {
           });
         }
 
-        const query = `artist:${props.artist} track:${props.name}`;
+        const query = encodeURIComponent(`artist:${props.artist} track:${props.name}`);
         const spotifyUrl = encodeURI(
           `https://open.spotify.com/search/${query}?si`
         );


### PR DESCRIPTION
Currently the title or artist will be missing parts of the string if they contain special characters, since the `query` in the URL isn't encoded.